### PR TITLE
We should be able to require("fs-lint") when installed locally.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "fs-lint",
   "version": "1.0.1",
   "description": "File naming consistency verification tool.",
+  "main": "lib/fs-lint.js",
   "keywords": [
     "file",
     "files",


### PR DESCRIPTION
Since there is no lib/index.js, without this property, you can not require the module in a reliable way.

Noticed this was not set. Cool project. :-)
