### PR TITLE
chore: update glob dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "commander": "2.0.0",
-    "glob": "3.2.6",
+    "glob": "^7.1.4",
     "lodash": "1.3.1",
     "source-map-support": "0.1.8",
     "sysexits": "1.0.0",


### PR DESCRIPTION
This PR updates https://github.com/isaacs/node-glob/blob/master/package.json to the most recent version